### PR TITLE
Add h-entry markup to default template

### DIFF
--- a/templates/default.html
+++ b/templates/default.html
@@ -35,25 +35,25 @@
 		<div id="idSnapContent" class="snap-content">
 			<div class="divVersionNumber" id="idVersionNumber">
 				</div>
-			<div class="divMywordPage">
+			<div class="divMywordPage h-entry">
 				<div class="divPageTop" id="idPageTop">
 					<div class="divBackgroundImage" id="idBackgroundImage">
 						</div>
 					<div class="divTextBackground">
 						</div>
 					<div class="divPageTopText" id="idPageTopText">
-						<div class="divPageByline" id="idPageByline">
+						<div class="divPageByline h-card u-author" id="idPageByline">
 							</div>
-						<div class="divPageTitle" id="idPageTitle">
+						<div class="divPageTitle p-name" id="idPageTitle">
 							[%ogtitle%]
 							</div>
-						<div class="divPageDescription" id="idPageDescription">
+						<div class="divPageDescription p-summary" id="idPageDescription">
 							[%ogdescription%]
 							</div>
 						</div>
 					</div>
 				<div class="divPageBody">
-					<div class="divEssayText" id="idEssayText">
+					<div class="divEssayText e-content" id="idEssayText">
 						[%renderedtext%]
 						</div>
 					<div class="divComments">   

--- a/templates/default.html
+++ b/templates/default.html
@@ -43,7 +43,7 @@
 						</div>
 					<div class="divPageTopText" id="idPageTopText">
 						<div class="divPageByline h-card u-author" id="idPageByline">
-							by <a class="u-url p-name" ref="[%authorwebsite%]">[%authorname%]</a> 
+							by <a class="u-url p-name" href="[%authorwebsite%]">[%authorname%]</a> 
 							<a class="u-url" href="https://twitter.com/[%twscreenname%]">[%twscreenname%]</a>
 							</div>
 						<div class="divPageTitle p-name" id="idPageTitle">

--- a/templates/default.html
+++ b/templates/default.html
@@ -43,6 +43,8 @@
 						</div>
 					<div class="divPageTopText" id="idPageTopText">
 						<div class="divPageByline h-card u-author" id="idPageByline">
+							by <a class="u-url p-name" ref="[%authorwebsite%]">[%authorname%]</a> 
+							<a class="u-url" href="https://twitter.com/[%twscreenname%]">[%twscreenname%]</a>
 							</div>
 						<div class="divPageTitle p-name" id="idPageTitle">
 							[%ogtitle%]
@@ -56,6 +58,8 @@
 					<div class="divEssayText e-content" id="idEssayText">
 						[%renderedtext%]
 						</div>
+					<a class="u-url" href="[%ogurl%]">#</a>
+					<time class="dt-published" datetime="[%when%]"></time>
 					<div class="divComments">   
 						[%disquscomments%]
 						</div>


### PR DESCRIPTION
This makes it compatible with indieweb markup for webmention support, and adds the timestamp, author and permalink to the rendered HTML so they show up in search indexes and other web crawlers.
